### PR TITLE
ci: Fix release notes are always outdated

### DIFF
--- a/.github/workflows/update-best-of-list.yml
+++ b/.github/workflows/update-best-of-list.yml
@@ -37,8 +37,10 @@ jobs:
           --libraries-key=${{ secrets.LIBRARIES_KEY }}
           --github-key=${{ secrets.GITHUB_TOKEN }}
           --gitee-key=${{ secrets.GITEE_API_KEY }}
-      - name: Show latest changes
-        run: cat latest-changes.md >> $GITHUB_STEP_SUMMARY
+      - name: Report latest changes
+        run: |
+          echo "# Best-of update: ${{ env.VERSION  }}" >> "$GITHUB_STEP_SUMMARY"
+          cat latest-changes.md >> "$GITHUB_STEP_SUMMARY"
       - name: Create pull request
         uses: peter-evans/create-pull-request@v5
         with:
@@ -49,6 +51,10 @@ jobs:
           body: |
             To finish this update: Select `Merge pull request` below and `Confirm merge`.
             Also, make sure to publish the created draft release in the [releases section](../releases) as well.
+      - name: Switch to updated branch
+        # “Create pull request” committed to a new branch without switching to it,
+        # but “Publish release” needs the updated file.
+        run: git switch "${{ env.BRANCH_PREFIX }}${{ env.VERSION  }}"
       - name: Publish release
         uses: softprops/action-gh-release@v1
         env:

--- a/.github/workflows/update-best-of-list.yml
+++ b/.github/workflows/update-best-of-list.yml
@@ -37,6 +37,8 @@ jobs:
           --libraries-key=${{ secrets.LIBRARIES_KEY }}
           --github-key=${{ secrets.GITHUB_TOKEN }}
           --gitee-key=${{ secrets.GITEE_API_KEY }}
+      - name: Show latest changes
+        run: cat latest-changes.md >> $GITHUB_STEP_SUMMARY
       - name: Create pull request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
## 这个拉取请求做了什么？
<!-- 把“[ ]”改成“[x]”以打✓ -->

- [x] 修改配置

## 更改
<!--
请在此节介绍更改。（若比较简单，比如只是添加项目，可以不写。）
如果涉及多个独立项目，请尽量分成多个拉取请求。
-->

Fixes #147.

- Add a job summary.
- Switch to the updated branch before releasing.

Test run: https://github.com/YDX-2147483647/best-of-bits/actions/runs/6996148084 .

## 最后检查
<!--
[] → [x] ⇒ ✓
最好全都完成；赶时间的话可忽略。
-->

- [x] 我已阅读[贡献者指南](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md)。
- [x] 我没有直接更改`README.md`。（`README.md`是从`projects.yaml`自动生成的）
